### PR TITLE
Remove `drupal:toggle:modules` command from post install hook

### DIFF
--- a/src/Blt/Plugin/Commands/ServerCommands.php
+++ b/src/Blt/Plugin/Commands/ServerCommands.php
@@ -37,18 +37,4 @@ class ServerCommands extends AcHooksCommand {
     return $this->collectionBuilder()->addTaskList($tasks)->run();
   }
 
-  /**
-   * This will be called after the drupal:install command.
-   *
-   * @hook post-command drupal:install
-   */
-  public function postDrupalInstallHook() {
-    try {
-      $this->invokeCommand('drupal:toggle:modules');
-    }
-    catch (\Throwable $e) {
-      $this->say($e->getMessage());
-    }
-  }
-
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- The `drupal:toggle:modules` command was removed from BLT in version `13.0.0`, which was released a year ago.
- We are calling for BLT version `^13.4` in our stack: https://github.com/SU-SWS/acsf-cardinalsites/blob/0a690c9ad89c3ff8330a220526c8529fbbb91dbd/composer.json#L102
- This hook code provided backwards compatibility with older versions of BLT, but is that necessary anymore?
- If not, we can remove this hook, since we're controlling modules per environment via configuration management.

# Needed By (Date)
- 🤷 

# Urgency
- low 

# Steps to Test

1. Do this
1. Then this
2. Then this

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
