### PR TITLE
Add conditional to check if $upload is set before calling wasSuccessful()

### DIFF
--- a/src/Blt/Plugin/Commands/PhpUnitCommands.php
+++ b/src/Blt/Plugin/Commands/PhpUnitCommands.php
@@ -118,7 +118,7 @@ class PhpUnitCommands extends PhpUnitCommand {
     $this->yell(sprintf('Coverage at %s%%. %s%% required.', $percent, $pass));
 
     $upload = $this->uploadCoverageCodeClimate();
-    if (!$upload->wasSuccessful()) {
+    if ($upload && !$upload->wasSuccessful()) {
       return $upload;
     }
     return $result;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Recent change throwing Fatal Error: https://github.com/SU-SWS/blt-sws/compare/083f9b8...33ba406#diff-3d3f40e3d8f59da7705b8debc19d7cc589a1c43ffee52fb53cc83b02c1cb723b
- Result of `uploadCoverageCodeClimate()` is stored in `$upload` var. 
- Result can sometimes be `NULL`.
- `$upload->wasSuccessful()` throws a fatal error when result is `NULL`:

See: https://github.com/SU-SWS/ace-sdssgryphon/actions/runs/12751713362/job/35539426219
```Fatal error: Uncaught Error: Call to a member function wasSuccessful() on null in /__w/ace-sdssgryphon/ace-sdssgryphon/vendor/su-sws/blt-sws/src/Blt/Plugin/Commands/PhpUnitCommands.php:121```

