### PR TITLE
Look for presence of acli_key in cloud_api.conf

### DIFF
--- a/src/Blt/Plugin/Commands/SwsCommandTrait.php
+++ b/src/Blt/Plugin/Commands/SwsCommandTrait.php
@@ -54,7 +54,7 @@ trait SwsCommandTrait {
   protected $cloudConfFilePath;
 
   /**
-   * @var 
+   * @var
    */
   protected $acquiaApi;
 
@@ -139,7 +139,15 @@ trait SwsCommandTrait {
 
     $this->say('<info>Establishing connection to Acquia API</info>');
     $cloudApiConfig = $this->loadCloudApiConfig();
-    $this->setCloudApiClient($cloudApiConfig['key'], $cloudApiConfig['secret']);
+    if ($cloudApiConfig['acli_key'] && $cloudApiConfig['keys']) {
+      $apiKeys = json_decode(json_encode($cloudApiConfig['keys']), TRUE);
+      $apiKey = $cloudApiConfig['acli_key'];
+      $apiSecret = $apiKeys[$apiKey]['secret'];
+    } else {
+      $apiKey = $cloudApiConfig['key'];
+      $apiSecret = $cloudApiConfig['secret'];
+    }
+    $this->setCloudApiClient($apiKey, $apiSecret);
   }
 
   /**
@@ -409,7 +417,7 @@ trait SwsCommandTrait {
         'secret' => $secret,
       ]);
       $this->acquiaApi  = Client::factory($connector);
-      
+
       $this->acquiaApplications = new Applications($this->acquiaApi);
       $this->acquiaEnvironments = new Environments($this->acquiaApi);
       $this->acquiaServers = new Servers($this->acquiaApi);

--- a/src/Blt/Plugin/Commands/SwsCommandTrait.php
+++ b/src/Blt/Plugin/Commands/SwsCommandTrait.php
@@ -131,7 +131,7 @@ trait SwsCommandTrait {
   /**
    * @throws \Acquia\Blt\Robo\Exceptions\BltException
    */
-  protected function connectAcquiaApi(){
+  protected function connectAcquiaApi() {
     $this->cloudConfDir = $_SERVER['HOME'] . '/.acquia';
     $this->setAppId();
     $this->cloudConfFileName = 'cloud_api.conf';
@@ -140,9 +140,8 @@ trait SwsCommandTrait {
     $this->say('<info>Establishing connection to Acquia API</info>');
     $cloudApiConfig = $this->loadCloudApiConfig();
     if ($cloudApiConfig['acli_key'] && $cloudApiConfig['keys']) {
-      $apiKeys = json_decode(json_encode($cloudApiConfig['keys']), TRUE);
       $apiKey = $cloudApiConfig['acli_key'];
-      $apiSecret = $apiKeys[$apiKey]['secret'];
+      $apiSecret = $cloudApiConfig['keys']->$apiKey->secret;
     } else {
       $apiKey = $cloudApiConfig['key'];
       $apiSecret = $cloudApiConfig['secret'];


### PR DESCRIPTION
`blt-sws` currently expects `cloud_api.conf` to be formatted like:
```
{"key":"ACQUIA KEY HERE","secret":"ACQUIA SECRET HERE"}
```

ACLI re-writes `cloud_api.conf` to look like:
```
array(4) {
  ["keys"]=>
  object(stdClass)#1050 (1) {
    ["ACQUIA KEY HERE"]=>
    object(stdClass)#1057 (3) {
      ["secret"]=>
      string(44) "ACQUIA SECRET HERE"
      ["uuid"]=>
      string(36) "UUID HERE"
    }
  }
  ["acli_key"]=>
  string(36) "ACQUIA KEY HERE"
}
```

This attempts to add support for the ACLI formatted way.