### PR TITLE
Make fail-fast option configurable.

### DIFF
--- a/src/Blt/Plugin/Commands/CodeceptionCommands.php
+++ b/src/Blt/Plugin/Commands/CodeceptionCommands.php
@@ -47,7 +47,7 @@ class CodeceptionCommands extends BltTasks {
 
     $tests = $this->getConfigValue('tests.codeception', []);
 
-    $this->failFast = $options['fail-fast'];
+    $this->failFast = (int) $options['fail-fast'];
 
     // Run only the test that was defined in the options.
     if (!empty($options['test'])) {

--- a/src/Blt/Plugin/Commands/CodeceptionCommands.php
+++ b/src/Blt/Plugin/Commands/CodeceptionCommands.php
@@ -15,6 +15,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CodeceptionCommands extends BltTasks {
 
   /**
+   * Fail fast option.
+   *
+   * @var int
+   */
+  protected $failFast;
+
+  /**
    * Run all the codeception tests defined in blt.yml.
    *
    * @param array $options
@@ -27,15 +34,20 @@ class CodeceptionCommands extends BltTasks {
    * @aliases tests:codeception codeception
    * @options test The key of the tests to run.
    * @options suite only run a specific suite instead of all suites.
+   * @options stop after nth failure (defaults to 1)
    */
   public function runCodeceptionTests(array $options = [
     'test' => NULL,
     'suite' => NULL,
     'group' => NULL,
-  ]) {
+    'fail-fast' => NULL,
+  ])
+  {
     $failed_test = NULL;
 
     $tests = $this->getConfigValue('tests.codeception', []);
+
+    $this->failFast = $options['fail-fast'];
 
     // Run only the test that was defined in the options.
     if (!empty($options['test'])) {
@@ -96,13 +108,16 @@ class CodeceptionCommands extends BltTasks {
       ->arg($suite)
       ->option('steps')
       ->option('config', 'tests', '=')
-      ->option('fail-fast')
       ->option('override', "paths: output: ../artifacts/$suite", '=')
       ->option('html')
       ->option('xml');
 
     if (getenv('CI')) {
       $test->option('env', 'ci', '=');
+    }
+
+    if ($this->failFast) {
+      $test->option('fail-fast', $this->failFast, '=');
     }
 
     if ($group = $this->input()->getOption('group')) {
@@ -130,5 +145,4 @@ class CodeceptionCommands extends BltTasks {
 
     return $test_result;
   }
-
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
It would be nice to be able to run tests through codeception and not stop running after a single failure. This makes `--fail-fast` a configurable option when running codeception through BLT.

BEFORE:
```
// Tests are always run with the --fail-fast option
blt codeception --suite=functional
[Exec] Running vendor/bin/codecept run functional --steps --config=tests --override='paths: output: ../artifacts/functional' --html --xml --fail-fast
```

AFTER:
```
// Tests can be run with fail-fast enabled and choose the desired amount of failures
blt codeception --suite=functional --fail-fast=2
[Exec] Running vendor/bin/codecept run functional --steps --config=tests --override='paths: output: ../artifacts/functional' --html --xml --fail-fast=2

// Tests can be run without fail-fast enabled
blt codeception --suite=functional
[Exec] Running vendor/bin/codecept run functional --steps --config=tests --override='paths: output: ../artifacts/functional' --html --xml
```

The only concern I have about this is this changes the default value from on to off and repo's would inherit the new default of not running with fail fast after upgrading, when they previously did.